### PR TITLE
Auth status fxn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.7.8
+Hotfix on new `authStatus()` fxn; the stale check now ensures that the other fields are non-empty.
+
 # v1.7.7
 Updated the trial stripe plan to reflect the new free tier
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eximchain/dappbot-types",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "description": "Typescript bindings to interact with the DappBot API",
   "main": "build/index.js",
   "types": "spec/index.ts",

--- a/spec/user/user.ts
+++ b/spec/user/user.ts
@@ -139,12 +139,14 @@ export function isAuthData(val:any): val is AuthData {
  * @param val 
  */
 export function authStatus(val:AuthData) {
-  let isEmpty = val.RefreshToken === '' || val.Authorization === '';
-  let expiryDate = Date.parse(val.ExpiresAt);
-  let isStale = expiryDate !== NaN && Date.now() > expiryDate;
+  let { RefreshToken, Authorization, User, ExpiresAt} = val;
+  let isEmpty = [RefreshToken, Authorization, User.Email].includes('');
+  let expiryDate = Date.parse(ExpiresAt);
+  let notExpired = expiryDate !== NaN && Date.now() < expiryDate;
   return {
-    isActive : !isStale && !isEmpty,
-    isStale, isEmpty
+    isActive : !isEmpty && notExpired,
+    isStale : !isEmpty && !notExpired,
+    isEmpty
   }
 }
 


### PR DESCRIPTION
The `isStale` function previously returned true for empty authData because it was only checking the date field -- now the boolean also depends on the data being non-empty